### PR TITLE
Fixed always show pagination bug

### DIFF
--- a/src/lib/list/list-super.tsx
+++ b/src/lib/list/list-super.tsx
@@ -228,7 +228,8 @@ const ListSuper = ({
       nPerPage
     );
 
-    const showPagination = config.pagination ? config.pagination : true;
+    const showPagination =
+      typeof config.pagination !== 'undefined' ? config.pagination : true;
 
     return (
       <ListWrapper>


### PR DESCRIPTION
## Description
The condition to check for `config.pagination` was incorrect hence the bug. This PR solves it.

**Types of changes**
Keep the one that apply:
- Bugfix (non-breaking change which fixes an issue)

## Changelog
#### Changed
- condition for `config.pagination`