### PR TITLE
Fixed header cell bug when there's any empty labels

### DIFF
--- a/src/lib/list/list-super.tsx
+++ b/src/lib/list/list-super.tsx
@@ -240,12 +240,6 @@ const ListSuper = <A,>({
 
     const renderHeaders = (): (JSX.Element | null)[] => {
       return def.map((h, i) => {
-        if (!h.label) {
-          return null;
-        }
-
-        const label = h.label || h.name;
-
         const order = isSort(h) ? (
           <OrderController
             descAsc={sortAttribute === h.name ? sortDescAsc : null}
@@ -267,7 +261,7 @@ const ListSuper = <A,>({
 
         return (
           <HeaderUnit key={i}>
-            {label} {order} {filter}
+            {h.label || ''} {order} {filter}
           </HeaderUnit>
         );
       });


### PR DESCRIPTION
## Description
If there's an empty label in the definition the header cells are messed up. This PR fixes that.

**Types of changes**
Keep the one that apply:
- Bugfix (non-breaking change which fixes an issue)